### PR TITLE
Add "smart mode" toggle

### DIFF
--- a/custom_components/jbl_integration/button.py
+++ b/custom_components/jbl_integration/button.py
@@ -30,6 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         JBLButton(coordinator,entry,"source-hdmi-switch","HDMI","mdi:video-input-hdmi"),
         JBLButton(coordinator,entry,"bluetooth","Bluetooth","mdi:bluetooth"),
         JBLButton(coordinator,entry,"source-tv","TV","mdi:television-box"),
+        JBLButton(coordinator,entry,"surround","Smart Mode","mdi:surround-sound"),
     ])
 
 class JBLButton(ButtonEntity):


### PR DESCRIPTION
Decompiling the APK for the Android companion app, I found an additional command that's not visible in the UI: "surround". This command toggles Smart Mode (https://support.jbl.com/us/en/howto/jbl-bar-9-1-lacking-dialogue-too-much-surround-us/000017755.html).

Many prefer would prefer for Smart Mode to be off on startup, but this is not supported by JBL. But with a button in home assistant, it's easy to set up an automation that turns off smart mode when the bar turns on.

Tested and works on Bar 1000, not tested on any other models. As far as I know, there's no way to query whether smart mode is on or off.