### PR TITLE
Add EQ preset selector and fix critical bugs

### DIFF
--- a/custom_components/jbl_integration/__init__.py
+++ b/custom_components/jbl_integration/__init__.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {"coordinator": coordinator}
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "switch","number","button","binary_sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "switch","number","button","binary_sensor","select"])
 
 
     return True
@@ -74,6 +74,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_unload(entry, "number")
     await hass.config_entries.async_forward_entry_unload(entry, "button")
     await hass.config_entries.async_forward_entry_unload(entry, "binary_sensor")
+    await hass.config_entries.async_forward_entry_unload(entry, "select")
 
     hass.data[DOMAIN].pop(entry.entry_id)
     return True

--- a/custom_components/jbl_integration/coordinator.py
+++ b/custom_components/jbl_integration/coordinator.py
@@ -107,6 +107,7 @@ class Coordinator(DataUpdateCoordinator):
         combined_data = {
             **await self.requestInfo(),
             **await self.getEQ(),
+            **await self.getEQPresets(),
             **await self.getNightMode(),
             **await self.getRearSpeaker(),
             **await self.getSmartMode(),
@@ -480,3 +481,83 @@ class Coordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.error("Error setting PureVoice: %s", str(e))
                 return {}
+
+    async def getEQPresets(self):
+        """Fetch the list of EQ presets and the currently active one."""
+        if not self.newFirmware:
+            return {}
+
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        url = f'https://{self.address}/httpapi.asp?command=getEQList'
+        headers = {'Accept-Encoding': "gzip"}
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with asyncio.timeout(10):
+                    async with session.get(url, headers=headers, ssl=self.sslcontext) as response:
+                        if response.status == 200:
+                            response_text = await response.text()
+                            response_json = json.loads(response_text)
+                            _LOGGER.debug("EQ Presets Response: %s", response_text)
+
+                            eq_list = response_json.get("eq_list", [])
+                            active_id = str(response_json.get("active_eq_id", "0"))
+
+                            preset_map = {}
+                            preset_data = {}
+                            active_name = None
+                            for item in eq_list:
+                                eq_id = str(item.get("eq_id", ""))
+                                eq_name = item.get("eq_name", f"Preset {eq_id}")
+                                preset_map[eq_id] = eq_name
+                                preset_data[eq_id] = item
+                                if eq_id == active_id:
+                                    active_name = eq_name
+
+                            if not active_name and preset_map:
+                                active_name = next(iter(preset_map.values()))
+
+                            return {
+                                "eq_preset_map": preset_map,
+                                "eq_preset_data": preset_data,
+                                "eq_active_preset": active_name,
+                                "eq_active_id": active_id,
+                            }
+                        else:
+                            _LOGGER.error("Failed to get EQ presets: %s", response.status)
+                            return {}
+            except Exception as e:
+                _LOGGER.warning("Error getting EQ presets: %s", str(e))
+                return {}
+
+    async def setActiveEQPreset(self, eq_id: str):
+        """Set the active EQ preset by its ID, sending full payload."""
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        preset_data = self.data.get("eq_preset_data", {})
+        preset = preset_data.get(eq_id)
+        if not preset:
+            _LOGGER.error("EQ preset data not found for id: %s", eq_id)
+            return
+
+        send_payload = json.dumps({
+            "active_eq_id": eq_id,
+            "band": preset.get("band", 7),
+            "eq_payload": preset.get("eq_payload", {}),
+        })
+
+        url = f'https://{self.address}/httpapi.asp'
+        headers = {'Accept-Encoding': "gzip"}
+        payload = f'command=setActiveEQ&payload={send_payload}'
+        _LOGGER.debug("Setting EQ preset: %s", payload)
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with asyncio.timeout(10):
+                    async with session.post(url, headers=headers, data=payload, ssl=self.sslcontext) as response:
+                        if response.status != 200:
+                            _LOGGER.error("Failed to set EQ preset: %s", response.status)
+                        else:
+                            _LOGGER.debug("EQ preset set successfully to id: %s", eq_id)
+            except Exception as e:
+                _LOGGER.error("Error setting EQ preset: %s", str(e))

--- a/custom_components/jbl_integration/coordinator.py
+++ b/custom_components/jbl_integration/coordinator.py
@@ -9,6 +9,7 @@ import certifi
 from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_UUID, CONF_ADDRESS, CONF_SCAN_INTERVAL
+from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -221,8 +222,7 @@ class Coordinator(DataUpdateCoordinator):
                             return {}
         except Exception as e:
             _LOGGER.error("Error fetching data: %s", str(e))
-            raise ConfigEntryNotReady(f"Timeout while connecting to {self.address}")
-            return {}
+            raise ConfigEntryNotReady(f"Timeout while connecting to {self.address}") from e
             
     async def requestInfo(self):
         # Disable SSL warnings
@@ -332,7 +332,17 @@ class Coordinator(DataUpdateCoordinator):
                             _LOGGER.debug("EQ Response text: %s", response_text)
                             #get data out of JSON
                             if self.newFirmware:
-                                gain = response_json["eq_list"][4]["eq_payload"]["gain"]
+                                active_id = str(response_json.get("active_eq_id", "0"))
+                                active_preset = None
+                                for item in response_json.get("eq_list", []):
+                                    if str(item.get("eq_id", "")) == active_id:
+                                        active_preset = item
+                                        break
+                                if active_preset is None and response_json.get("eq_list"):
+                                    active_preset = response_json["eq_list"][0]
+                                if active_preset is None:
+                                    return {}
+                                gain = active_preset["eq_payload"]["gain"]
                                 eqList = {
                                         "125Hz":gain[0],    #Min -9, Max 6, step 0.5
                                         "250Hz":gain[1],    #Min -6, Max 6, step 0.5

--- a/custom_components/jbl_integration/select.py
+++ b/custom_components/jbl_integration/select.py
@@ -1,0 +1,92 @@
+"""Select platform for JBL integration."""
+import asyncio
+import logging
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import Coordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the JBL select platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    entities = []
+    if coordinator.data.get("eq_preset_map"):
+        entities.append(JBLEQPresetSelect(entry, coordinator))
+
+    async_add_entities(entities)
+
+
+class JBLEQPresetSelect(SelectEntity):
+    """Select entity for JBL EQ presets."""
+
+    def __init__(self, entry: ConfigEntry, coordinator: Coordinator):
+        """Initialize the select."""
+        self._entry = entry
+        self.coordinator = coordinator
+        self.entity_id = f"select.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_eq_preset"
+
+    @property
+    def name(self):
+        """Return the name of the select."""
+        return "JBL EQ Preset"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for the select."""
+        return f"jbl_eq_preset_{self._entry.entry_id}"
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return "mdi:tune-variant"
+
+    @property
+    def device_info(self):
+        """Return device information about this entity."""
+        return self.coordinator.device_info
+
+    @property
+    def options(self):
+        """Return the list of available EQ preset names."""
+        preset_map = self.coordinator.data.get("eq_preset_map", {})
+        return list(preset_map.values()) if preset_map else []
+
+    @property
+    def current_option(self):
+        """Return the currently active EQ preset name."""
+        return self.coordinator.data.get("eq_active_preset")
+
+    async def async_select_option(self, option: str):
+        """Set the EQ preset."""
+        preset_map = self.coordinator.data.get("eq_preset_map", {})
+        for eq_id, eq_name in preset_map.items():
+            if eq_name == option:
+                await self.coordinator.setActiveEQPreset(eq_id)
+                # Optimistic update
+                self.coordinator.data["eq_active_preset"] = eq_name
+                self.coordinator.data["eq_active_id"] = eq_id
+                self.async_write_ha_state()
+                # Delay then refresh to confirm
+                await asyncio.sleep(1)
+                await self.coordinator.async_request_refresh()
+                return
+        _LOGGER.error("EQ preset not found: %s", option)
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    async def async_added_to_hass(self):
+        """When entity is added to hass."""
+        self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))
+
+    async def async_update(self):
+        """Update the entity."""
+        await self.coordinator.async_request_refresh()

--- a/custom_components/jbl_integration/sensor.py
+++ b/custom_components/jbl_integration/sensor.py
@@ -51,7 +51,7 @@ class JBLSensor(Entity):
         self._entry = entry
         self.entityName = name
         self.entityicon = icon
-        self.entity_id = f"button.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = f"sensor.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_{self.entityName.replace(' ', '_').lower()}"
         self.infoString = infoString
 
     @property
@@ -76,7 +76,7 @@ class JBLSensor(Entity):
 
     @property
     def enabled(self):
-        return false
+        return False
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Summary
- New `select.py` entity that exposes EQ presets (JBL Signature, Vocal, Energetic, Chill, Customize) as a dropdown in HA
- Added `getEQPresets()` and `setActiveEQPreset()` to coordinator
- Optimistic UI update with delayed refresh for responsiveness
- Only active on new firmware (JBL One 3.0+)

### Bug fixes
- Import `ConfigEntryNotReady` (was raising NameError on connection failure)
- Fix sensor entity_id using `button.` prefix instead of `sensor.`
- Fix `return false` (lowercase) in sensor.enabled
- Look up active EQ preset by `eq_id` instead of hardcoded `eq_list[4]`

## Test plan
- [x] Tested on JBL Authentics 200 with firmware 3.0+
- [x] Preset selection changes sound profile on device
- [x] UI updates correctly after selection
- [x] EQ sliders show values of the active preset