### PR TITLE
fixes: proper sanitization of the entity ids resolving warnings at in…

### DIFF
--- a/custom_components/jbl_integration/binary_sensor.py
+++ b/custom_components/jbl_integration/binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +32,12 @@ class JBLChargingSensor(BinarySensorEntity):
         self.number = arrayNumber
         self._entry = entry
         self.entityName = "Charging"
-        self.entity_id = f"binary_sensor.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_{self.coordinator.data["Rears"][self.number]["channel"].lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "binary_sensor",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.coordinator.data["Rears"][self.number]["channel"],
+            self.entityName,
+        )
 
     @property
     def name(self):
@@ -82,7 +88,12 @@ class JBLDockedSensor(BinarySensorEntity):
         self.number = arrayNumber
         self._entry = entry
         self.entityName = "Docked"
-        self.entity_id = f"binary_sensor.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_{self.coordinator.data["Rears"][self.number]["channel"].lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "binary_sensor",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.coordinator.data["Rears"][self.number]["channel"],
+            self.entityName,
+        )
 
     @property
     def name(self):
@@ -133,7 +144,12 @@ class JBLOnlineSensor(BinarySensorEntity):
         self.number = arrayNumber
         self._entry = entry
         self.entityName = "Online"
-        self.entity_id = f"binary_sensor.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_{self.coordinator.data["Rears"][self.number]["channel"].lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "binary_sensor",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.coordinator.data["Rears"][self.number]["channel"],
+            self.entityName,
+        )
 
     @property
     def name(self):

--- a/custom_components/jbl_integration/button.py
+++ b/custom_components/jbl_integration/button.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import Coordinator
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +44,11 @@ class JBLButton(ButtonEntity):
         self.entityName = name
         self.entityicon = icon
         self.actionstring = actionstring
-        self.entity_id = f"button.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "button",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.entityName,
+        )
         
 
     @property
@@ -74,3 +79,5 @@ class JBLButton(ButtonEntity):
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.coordinator._send_command(self.actionstring)
+
+        

--- a/custom_components/jbl_integration/entity.py
+++ b/custom_components/jbl_integration/entity.py
@@ -1,0 +1,13 @@
+"""Shared entity helpers for the JBL integration."""
+
+from homeassistant.util import slugify
+
+
+def entity_id_slug(value: str) -> str:
+    """Return a Home Assistant-safe slug for manual entity IDs."""
+    return slugify(value).replace("-", "_")
+
+
+def build_entity_id(platform: str, *parts: str) -> str:
+    """Build a sanitized entity ID from a platform and name parts."""
+    return f"{platform}.{ '_'.join(entity_id_slug(part) for part in parts if part) }"

--- a/custom_components/jbl_integration/number.py
+++ b/custom_components/jbl_integration/number.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.event import async_track_state_change
 
 from .const import DOMAIN
 from .coordinator import Coordinator
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +42,11 @@ class JBLVolumeNumber(NumberEntity):
         self._entry = entry
         self._value  = 0
         self.coordinator = coordinator
-        self.entity_id = f"number.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_{self.name.lower()}"
+        self.entity_id = build_entity_id(
+            "number",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.name,
+        )
         
 
     @property
@@ -112,7 +117,11 @@ class JBLEqNumber(NumberEntity):
         self._value  = 0        
         self.entityName = eqLevel
         self.coordinator = coordinator
-        self.entity_id = f"number.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_{self.entityName.lower()}"
+        self.entity_id = build_entity_id(
+            "number",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.entityName,
+        )
 
     @property
     def name(self):

--- a/custom_components/jbl_integration/select.py
+++ b/custom_components/jbl_integration/select.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import Coordinator
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +30,11 @@ class JBLEQPresetSelect(SelectEntity):
         """Initialize the select."""
         self._entry = entry
         self.coordinator = coordinator
-        self.entity_id = f"select.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_eq_preset"
+        self.entity_id = build_entity_id(
+            "select",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            "eq_preset",
+        )
 
     @property
     def name(self):

--- a/custom_components/jbl_integration/sensor.py
+++ b/custom_components/jbl_integration/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.sensor import (
 
 from .const import DOMAIN
 from .coordinator import Coordinator
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +52,11 @@ class JBLSensor(Entity):
         self._entry = entry
         self.entityName = name
         self.entityicon = icon
-        self.entity_id = f"sensor.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "sensor",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.entityName,
+        )
         self.infoString = infoString
 
     @property
@@ -111,7 +116,12 @@ class JBLRearSensor(Entity):
         self.number = arrayNumber
         self._entry = entry
         self.entityName = "Battery"
-        self.entity_id = f"sensor.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_{self.coordinator.data["Rears"][self.number]["channel"].lower()}_{self.entityName.replace(' ', '_').lower()}"
+        self.entity_id = build_entity_id(
+            "sensor",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            self.coordinator.data["Rears"][self.number]["channel"],
+            self.entityName,
+        )
 
     @property
     def name(self):

--- a/custom_components/jbl_integration/switch.py
+++ b/custom_components/jbl_integration/switch.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.event import async_track_state_change
 
 from .const import DOMAIN
 from .coordinator import Coordinator
+from .entity import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +35,11 @@ class JBLPowerSwitch(SwitchEntity):
         self._entry = entry
         self._is_on = False
         self.coordinator = coordinator        
-        self.entity_id = f"switch.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_power"
+        self.entity_id = build_entity_id(
+            "switch",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            "power",
+        )
 
     @property
     def name(self):
@@ -107,7 +112,11 @@ class NightModeSwitch(SwitchEntity):
         self._entry = entry
         self._is_on = False
         self.coordinator = coordinator        
-        self.entity_id = f"switch.{self.coordinator.device_info.get("name", "jbl_integration").replace(' ', '_').lower()}_NightMode"
+        self.entity_id = build_entity_id(
+            "switch",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            "NightMode",
+        )
 
     @property
     def name(self):
@@ -163,7 +172,11 @@ class SmartModeSwitch(SwitchEntity):
         self._entry = entry
         self._is_on = False
         self.coordinator = coordinator        
-        self.entity_id = f"switch.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_smart_mode"
+        self.entity_id = build_entity_id(
+            "switch",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            "smart_mode",
+        )
 
     @property
     def name(self):
@@ -222,7 +235,11 @@ class PureVoiceModeSwitch(SwitchEntity):
         self._entry = entry
         self._is_on = False
         self.coordinator = coordinator        
-        self.entity_id = f"switch.{self.coordinator.device_info.get('name', 'jbl_integration').replace(' ', '_').lower()}_pure_voice"
+        self.entity_id = build_entity_id(
+            "switch",
+            self.coordinator.device_info.get("name", "jbl_integration"),
+            "pure_voice",
+        )
 
     @property
     def name(self):


### PR DESCRIPTION
The integration throws a few warning at startup because the entity ids include characters that should be sanitized. 
The change centralizes the method for sanitation and uses the home assistants slugify to make sure the ids are valid.

fixes: #45