### PR TITLE
Fix blocking SSL context creation in event loop

### DIFF
--- a/custom_components/jbl_integration/coordinator.py
+++ b/custom_components/jbl_integration/coordinator.py
@@ -7,6 +7,7 @@ import urllib3
 import ssl
 import certifi
 from datetime import timedelta
+from functools import partial
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_UUID, CONF_ADDRESS, CONF_SCAN_INTERVAL
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -23,11 +24,10 @@ class Coordinator(DataUpdateCoordinator):
         self.pollingRate = scan_interval
         self.data = {}
 
-        ssl_context = ssl.create_default_context(cafile=certifi.where())
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        self.sslcontext = ssl_context
-    
+        # Don't create SSL context here - it will be created asynchronously
+        # to avoid blocking the event loop (see _create_ssl_context)
+        self.sslcontext = None
+        
         if hass != None and entry != None:
             self._entry = entry
             self.hass = hass
@@ -39,11 +39,38 @@ class Coordinator(DataUpdateCoordinator):
                 update_interval=timedelta(seconds=int(scan_interval)),
             )
 
+    async def _create_ssl_context(self):
+        """Create SSL context in executor to avoid blocking the event loop."""
+        loop = asyncio.get_event_loop()
+
+        # Run blocking SSL context creation in executor
+        ssl_context = await loop.run_in_executor(
+            None,
+            partial(ssl.create_default_context, cafile=certifi.where())
+        )
+
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+        return ssl_context
+
     async def _SetupDeviceInfo(self):
-        #Setting up cert        
+        """Setting up cert and device info."""
+        # Create SSL context if not already created
+        if self.sslcontext is None:
+            self.sslcontext = await self._create_ssl_context()
+
+        # Load cert chain in executor to avoid blocking
         cert_path = self.hass.config.path("custom_components/jbl_integration/Cert.pem")
         key_path = self.hass.config.path("custom_components/jbl_integration/Key.pem")
-        self.sslcontext.load_cert_chain(certfile=cert_path, keyfile=key_path)
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            self.sslcontext.load_cert_chain,
+            cert_path,
+            key_path
+        )
         
         device_info = await self.getDeviceInfo()
         device_Type = await self.getDeviceType() 


### PR DESCRIPTION
Fixes #33 

This fixes a `homeassistant.util.loop` warning:
"Detected blocking call to load_verify_locations/load_cert_chain
inside the event loop".

SSL context creation (`ssl.create_default_context`) and certificate
loading (`load_cert_chain`) are synchronous, blocking I/O calls. They
were being executed directly inside `__init__` and `_SetupDeviceInfo`,
blocking the Home Assistant event loop.

## Changes
- SSL context is no longer created in `__init__`; `self.sslcontext`
  starts as `None`.
- New `_create_ssl_context()` helper runs
  `ssl.create_default_context()` via `loop.run_in_executor()`.
- `_SetupDeviceInfo()` now creates the SSL context lazily (if not
  already created) and runs `load_cert_chain()` via
  `loop.run_in_executor()` as well.