### PR TITLE
Fix invalid 3-tuple device identifier

### DIFF
--- a/custom_components/jbl_integration/coordinator.py
+++ b/custom_components/jbl_integration/coordinator.py
@@ -61,7 +61,7 @@ class Coordinator(DataUpdateCoordinator):
         self._device_info = {
             "identifiers": {
                 (DOMAIN, self._entry.entry_id),
-                (DOMAIN, mac_address,uuid),
+                (DOMAIN, f"{mac_address}_{uuid}"),
                 (DOMAIN, str(uuid).replace("-", "")),
                 (DOMAIN, self.address),
                 },


### PR DESCRIPTION
The `identifiers` set built in `_SetupDeviceInfo()` contains one
entry with 3 elements instead of the 2 required by the Home Assistant
device registry API:

```python
(DOMAIN, mac_address, uuid)
```

Any code — including unrelated third-party integrations — that
iterates over `device.identifiers` and unpacks each entry as
`domain, identifier` (the documented 2-tuple format) raises a
`ValueError: too many values to unpack (expected 2, got 3)` when it
reaches this entry. This was observed surfacing through
`electrolux_status`'s device registry cleanup routine, but the root
cause is the malformed identifier registered by this integration.

## Changes
- Combines `mac_address` and `uuid` into a single identifier value:
  `(DOMAIN, f"{mac_address}_{uuid}")`, making it a valid 2-tuple.
